### PR TITLE
97197622 adding docker push example

### DIFF
--- a/16.docker_push/Dockerfile
+++ b/16.docker_push/Dockerfile
@@ -1,0 +1,5 @@
+# base on latest ubuntu base image
+FROM ubuntu
+
+#do the thing
+RUN touch /codeship-docker-push-example

--- a/16.docker_push/after.sh
+++ b/16.docker_push/after.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ -e registry.cid ]; then
+  CID=`cat registry.cid`
+  docker stop $CID
+  docker rm $CID
+  rm registry.cid
+fi

--- a/16.docker_push/before.sh
+++ b/16.docker_push/before.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker run -d --cidfile ./registry.cid -p 5000:5000 registry
+

--- a/16.docker_push/codeship-services.yml
+++ b/16.docker_push/codeship-services.yml
@@ -1,0 +1,8 @@
+demo:
+  build:
+    image: localhost:5000/myapp
+    dockerfile_path: Dockerfile
+registry:
+  image: registry
+  ports:
+    - "5000:5000"

--- a/16.docker_push/codeship-steps.yml
+++ b/16.docker_push/codeship-steps.yml
@@ -1,0 +1,8 @@
+- service: demo
+  command: ls ./
+- service: demo
+  type: push
+  name: docker_push
+  image_name: localhost:5000/myapp
+  registry: localhost:5000
+  #encrypted_dockercfg_path: ./.dockercfg.encrypted

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,11 @@ all: test
 test:
 	@ for dir in $(shell find . -depth -type d | grep -v .git | grep -v ^11 | grep -v ^12 | grep ^./$ ); do \
 		echo $$dir; \
-		jet steps --dir=$$dir; \
+	 	if [ -f $$dir/before.sh ]; then \
+	 	  $$dir/before.sh; \
+	 	fi; \
+		jet steps --push=true --dir=$$dir; \
+	 	if [ -f $$dir/after.sh ]; then \
+	 	  $$dir/after.sh; \
+	 	fi; \
 	done


### PR DESCRIPTION
Depends on #3 

One of the larger changes in this is adding before/after scripts to be called around the steps. This is needed for docker push to run a private registry throughout the step executions. Alternatively we could request dockerhub/quay credentials to via env or otherwise, however this method requires no initial setup from the user.
