### PR TITLE
Use official Docker tag for dind example

### DIFF
--- a/14.add_docker/codeship-services.yml
+++ b/14.add_docker/codeship-services.yml
@@ -1,3 +1,3 @@
 adddocker:
-  image: jpetazzo/dind
+  image: docker:dind
   add_docker: true


### PR DESCRIPTION
Let's use an official image that's actively maintained :tada: 