### PR TITLE
Caching tutorial updates

### DIFF
--- a/17.caching/Dockerfile
+++ b/17.caching/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+
+RUN printenv

--- a/17.caching/Dockerfile
+++ b/17.caching/Dockerfile
@@ -1,8 +1,0 @@
-# base on latest ubuntu base image
-FROM ubuntu
-
-# do something that takes a long time
-RUN sleep 10s
-
-# do the thing
-RUN touch /codeship-docker-push-example

--- a/17.caching/Dockerfile
+++ b/17.caching/Dockerfile
@@ -1,3 +1,0 @@
-FROM busybox
-
-RUN printenv

--- a/17.caching/README.md
+++ b/17.caching/README.md
@@ -1,15 +1,6 @@
 ## 17.caching
 
-With this caching example, before a build is attempted a cache image is pulled from the registry. If this image is present it contributes to the docker image cache.
+[deprecated]
 
-To try this out start the registry, and then time different jet runs:
-
-```
-$ ./before.sh
-$ time jet steps --push --ci-branch=test  # ~2mins
-$ time jet steps --push --ci-branch=test  # ~20s due to caching plus no new images to push
-$ time jet steps --push --ci-branch=test  # ~20s
-$ ./after.sh
-```
-
-You can switch off the `cached` flag in the codeship-services file to see what difference it makes.
+This caching example has been deprecated because local builds running with the Jet CLI rely only on the local Docker registry.
+To learn more about how caching works, and how to use caching in your hosted builds, check out the [caching tutorial](http://codeship.com/documentation/docker/caching/).

--- a/17.caching/after.sh
+++ b/17.caching/after.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [ -e registry.cid ]; then
-  CID=`cat registry.cid`
-  docker stop $CID
-  docker rm $CID
-  rm registry.cid
-fi

--- a/17.caching/before.sh
+++ b/17.caching/before.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-docker run -d --cidfile ./registry.cid -p 5000:5000 registry

--- a/17.caching/codeship-services.yml
+++ b/17.caching/codeship-services.yml
@@ -1,9 +1,0 @@
-demo:
-  build:
-    image: localhost:5000/myapp
-    dockerfile_path: Dockerfile
-  cached: true
-registry:
-  image: registry
-  ports:
-    - "5000:5000"

--- a/17.caching/codeship-steps.yml
+++ b/17.caching/codeship-steps.yml
@@ -1,2 +1,0 @@
-- service: demo
-  command: ls -l

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -85,7 +85,6 @@
     path: 16.docker_push
 17demo:
   build:
-    image: quay.io/codeship/codeship-tool-examples
     dockerfile_path: Dockerfile
     path: 17.caching
   cached: true

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -83,11 +83,6 @@
     image: quay.io/codeship/codeship-tool-examples
     dockerfile_path: Dockerfile
     path: 16.docker_push
-17demo:
-  build:
-    dockerfile_path: Dockerfile
-    path: 17.caching
-  cached: true
 18app:
   build:
     dockerfile_path: Dockerfile.app

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -193,6 +193,3 @@
   registry: quay.io
   dockercfg_service: 19dockercfg_generator
 
-
-
-

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -179,9 +179,6 @@
   registry: quay.io
   image_tag: push_demo
   encrypted_dockercfg_path: dockercfg.encrypted
-- service: 17demo
-  name: 17
-  command: ls -l
 - name: 18
   service: 18test
   command: ab -n 100 -c 15 http://lb/


### PR DESCRIPTION
Since local caching is deprecated, we should remove the tutorial assets and explain where to find more documentation about caching on remote builds.