### PR TITLE
Updating sample dockercfg generator to return valid auth

### DIFF
--- a/19.dockercfg-service/dump_default_dockercfg.sh
+++ b/19.dockercfg-service/dump_default_dockercfg.sh
@@ -6,10 +6,9 @@ cat << EOF > "$1"
 {
   "auths": {
   	"$REGISTRY": {
-  		"auth": "$AUTH",
+		"auth": "dXNlcjpwYXNzCg==",
   		"email": ""
   	}
   }
 }
 EOF
-


### PR DESCRIPTION
user:pass base64 encoded, works with default registry
