### PR TITLE
Switching to the correct encrypted env file

### DIFF
--- a/11.encrypted-aes/codeship-services.yml
+++ b/11.encrypted-aes/codeship-services.yml
@@ -1,3 +1,3 @@
 checker:
   build: ./
-  encrypted_env_file: environment.encrypted.ci
+  encrypted_env_file: environment.encrypted


### PR DESCRIPTION
This change switches the encrypted env file used for this subtest to be one set up with the committed AES key, not the project one in CI.

Fixes #31 