### PR TITLE
Fix bad relative path in example 07

### DIFF
--- a/18.load-balancer/ab-with-backoff.sh
+++ b/18.load-balancer/ab-with-backoff.sh
@@ -8,7 +8,7 @@ function with_backoff {
   local attempt=0
   local exitCode=0
 
-  while [[ $attempt < $max_attempts ]]
+  while [[ $attempt -lt $max_attempts ]]
   do
     set +e
     "$@"

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -45,7 +45,7 @@
 07data:
   image: busybox
   volumes:
-    - ./tmp/07/:/artifacts
+    - ./07.volumes/tmp/:/artifacts
 08compiledemo:
   build: ./08.deployment-container
   dockerfile: Dockerfile.build


### PR DESCRIPTION
`./tmp/07` -> `./07.volumes/tmp/` ensures jet steps actual builds
successfully.