### PR TITLE
Add example of using an entrypoint in a service definition

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -121,6 +121,9 @@
       UNENCRYPTED: "my-unencrypted-build-arg"
     encrypted_args_file: 20.build-args/build_args.encrypted
     encrypted_args: n3gGLaQfbmNKz8ZVez+HS9/82LZBVP/+Sea2sD91cpdY69G2LF+CE54gOSOaGH7E8g==
+21entrypoint:
+  image: busybox
+  entrypoint: "ps"
 redis:
   image: redis:3.2.8
 postgres:
@@ -130,4 +133,3 @@ busybox:
 adddocker:
   image: docker:1.9-dind
   add_docker: true
-

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -192,4 +192,7 @@
 - name: 20
   service: 20buildargs
   command: /app/test-build-arg.sh
+- name: 21
+  service: 21entrypoint
+  command: "-o pid"
 


### PR DESCRIPTION
This demonstrates how an `entrypoint` can be configured for a service.