### PR TITLE
Hostname directive example

### DIFF
--- a/23.hostname/Dockerfile
+++ b/23.hostname/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine 
+
+RUN apk update && apk add iputils 
+
+ENTRYPOINT ["ping"]

--- a/23.hostname/codeship-services.yml
+++ b/23.hostname/codeship-services.yml
@@ -1,0 +1,3 @@
+app:
+  build: .
+  hostname: foo

--- a/23.hostname/codeship-steps.yml
+++ b/23.hostname/codeship-steps.yml
@@ -1,0 +1,2 @@
+- service: app
+  command: "-c 3 foo"

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -129,6 +129,10 @@
     path: 22.working_dir
     dockerfile: Dockerfile
   working_dir: /home
+23hostname:
+  build:
+    path: 23.hostname
+    dockerfile: Dockerfile
 redis:
   image: redis:3.2.8
 postgres:

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -133,6 +133,7 @@
   build:
     path: 23.hostname
     dockerfile: Dockerfile
+  hostname: foo
 redis:
   image: redis:3.2.8
 postgres:

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -198,3 +198,6 @@
 - name: 22
   service: 22workingdir
   command: ./script.sh
+- name: 23
+  service: 23hostname
+  command: "-c 3 foo"


### PR DESCRIPTION
Example `23.hostname/` shows how the hostname directive can be used to
configure a containers hostname.