### PR TITLE
Demonstrate support for upcoming depends_on directive

### DIFF
--- a/23.depends_on/Dockerfile
+++ b/23.depends_on/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.6
+
+RUN apk add --update curl
+
+ADD ./wait.sh /wait.sh

--- a/23.depends_on/codeship-services.yml
+++ b/23.depends_on/codeship-services.yml
@@ -1,0 +1,7 @@
+server:
+  image: python
+  command: python3 -m http.server
+app:
+  build: .
+  depends_on:
+    - server

--- a/23.depends_on/codeship-steps.yml
+++ b/23.depends_on/codeship-steps.yml
@@ -1,0 +1,2 @@
+- service: app
+  command: /wait.sh

--- a/23.depends_on/wait.sh
+++ b/23.depends_on/wait.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+function check() {
+  curl server:8000
+}
+
+TIMEOUT=10
+COUNT=0
+until check || [ $COUNT -eq $TIMEOUT ]
+do
+ sleep 1
+ COUNT=$((COUNT+1))
+done
+
+if [ $COUNT -eq $TIMEOUT ]; then
+  echo "Timeout" && exit 1
+fi

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -109,7 +109,7 @@
     dockerfile_path: Dockerfile
     path: 19.dockercfg-service
 19dockercfg_generator:
-  build: 
+  build:
     dockerfile_path: Dockerfile.generator
     path: 19.dockercfg-service
   encrypted_env_file: dockercfg.env.encrypted
@@ -117,7 +117,7 @@
   build:
     path: 20.build-args
     dockerfile: Dockerfile
-    args:  
+    args:
       UNENCRYPTED: "my-unencrypted-build-arg"
     encrypted_args_file: 20.build-args/build_args.encrypted
     encrypted_args: n3gGLaQfbmNKz8ZVez+HS9/82LZBVP/+Sea2sD91cpdY69G2LF+CE54gOSOaGH7E8g==
@@ -129,6 +129,12 @@
     path: 22.working_dir
     dockerfile: Dockerfile
   working_dir: /home
+23dependson:
+  build:
+    path: 23.depends_on
+    dockerfile: Dockerfile
+  depends_on:
+    - server
 redis:
   image: redis:3.2.8
 postgres:
@@ -138,3 +144,6 @@ busybox:
 adddocker:
   image: docker:1.9-dind
   add_docker: true
+server:
+  image: python
+  command: python3 -m http.server

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -198,3 +198,6 @@
 - name: 22
   service: 22workingdir
   command: ./script.sh
+- name: 23
+  service: 23dependson
+  command: ./wait.sh


### PR DESCRIPTION
This PR demonstrates how the `depends_on` directive will work in upcoming releases of `jet`.
For now the build on Codeship will break as expected.

see the `23.depends_on` directory for the new example behavior.