### PR TITLE
Using templates for env build args example

### DIFF
--- a/25.env_build_args/Dockerfile
+++ b/25.env_build_args/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.7
+
+ARG CI_STRING_TIME
+ARG CI
+
+RUN echo "This image was built at: ${CI_STRING_TIME}" && \
+    echo "CI=${CI}"

--- a/25.env_build_args/codeship-services.yml
+++ b/25.env_build_args/codeship-services.yml
@@ -1,0 +1,6 @@
+app:
+  build:
+    dockerfile: Dockerfile
+    args:
+        CI_STRING_TIME: "{{.StringTime}}"
+        CI: "{{.CI}}"

--- a/25.env_build_args/codeship-steps.yml
+++ b/25.env_build_args/codeship-steps.yml
@@ -1,0 +1,3 @@
+- service: app
+  name: app
+  command: echo "hello world"

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -150,7 +150,8 @@
     path: 25.env_build_args
     dockerfile: Dockerfile
     args:
-        CI_STRING_TIME: "foo" # will get replaced with the actual value at image build time
+        CI_STRING_TIME: "{{.StringTime}}"
+        CI: "{{.CI}}"
 
 redis:
   image: redis:3.2.8

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -145,6 +145,13 @@
   build:
     path: 24.healthchecks
     dockerfile: Dockerfile.elasticsearch
+25envbuildargs:
+  build:
+    path: 25.env_build_args
+    dockerfile: Dockerfile
+    args:
+        CI_STRING_TIME: "foo" # will get replaced with the actual value at image build time
+
 redis:
   image: redis:3.2.8
 postgres:

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -204,3 +204,6 @@
 - name: 24
   service: 24healthchecks
   command: curl -sL 24elasticsearch:9200
+- name: 25
+  service: 25envbuildargs
+  command: echo 25


### PR DESCRIPTION
See: https://app.codeship.com/projects/103513/builds/f74e4989-6109-459d-a65b-0bbc0c0bbc89?service=25envbuildargs#log-1e64308b-b8de-415b-b255-fe551848774e

Ex:

```yaml
app:
  build:
    dockerfile: Dockerfile
    args:
        CI_STRING_TIME: "{{.StringTime}}"
        CI: "{{.CI}}"
```