### PR TITLE
Elasticsearch no longer supports latest tag

### DIFF
--- a/24.healthchecks/Dockerfile.elasticsearch
+++ b/24.healthchecks/Dockerfile.elasticsearch
@@ -1,4 +1,4 @@
-FROM elasticsearch
+FROM elasticsearch:6.4.1
 
 COPY elasticsearch-healthcheck /usr/local/bin/
 


### PR DESCRIPTION
Was getting build error for Elasticsearch image: https://app.codeship.com/projects/103513/builds/dea055ae-a163-4396-a6c8-4d097909aa75?step=24

Seems they no longer support the default `latest` tag: https://hub.docker.com/_/elasticsearch/